### PR TITLE
feat: persist file writes eagerly with a live Files panel

### DIFF
--- a/app/src/components/compiler/fileViewer.tsx
+++ b/app/src/components/compiler/fileViewer.tsx
@@ -16,7 +16,7 @@ import {
   Download,
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { FILE_PREFIX } from '../../utils/constants';
+import { FILE_PREFIX, FILES_CHANGED_EVENT } from '../../utils/constants';
 
 interface FileEntry {
   name: string;
@@ -75,6 +75,23 @@ const FileViewer: React.FC<FileViewerProps> = ({ onOpenFile, open, onOpenChange,
     setFilter('');
     setCopied(false);
   }, [open, initialCreating, loadFiles]);
+
+  // Live updates: when the interpreter persists files mid-run (WRITEFILE/CLOSEFILE/end-of-run),
+  // refresh the list and the currently-viewed file so students can watch a file fill in.
+  useEffect(() => {
+    if (!open) return;
+    const handleFilesChanged = () => {
+      loadFiles();
+      setSelectedFile((cur) => {
+        if (!cur) return cur;
+        const latest = localStorage.getItem(FILE_PREFIX + cur.name);
+        if (latest === null) return null; // file was removed
+        return latest === cur.content ? cur : { ...cur, content: latest };
+      });
+    };
+    window.addEventListener(FILES_CHANGED_EVENT, handleFilesChanged);
+    return () => window.removeEventListener(FILES_CHANGED_EVENT, handleFilesChanged);
+  }, [open, loadFiles]);
 
   const handleSelectFile = (file: FileEntry) => {
     setSelectedFile(file);

--- a/app/src/interpreter/__tests__/interpreter.test.ts
+++ b/app/src/interpreter/__tests__/interpreter.test.ts
@@ -14,6 +14,7 @@ import { examples } from '../../data/examples';
 async function runCode(
   source: string,
   inputs: string[] = [],
+  fs: ServerVirtualFileSystem = new ServerVirtualFileSystem(),
 ): Promise<{ outputs: string[]; errors: PseudocodeError[] }> {
   const { tree, errors } = parse(source);
   if (errors.length > 0 || !tree) return { outputs: [], errors };
@@ -31,7 +32,7 @@ async function runCode(
       onError: () => {},
     },
     controller.signal,
-    new ServerVirtualFileSystem(),
+    fs,
   );
 
   // Feed queued inputs automatically
@@ -949,6 +950,26 @@ describe('A Level — random-access files', () => {
     ].join('\n') + '\n';
     const { outputs } = await runCode(code);
     expect(outputs).toEqual(['hello']);
+  });
+
+  it('persists a file even when the program forgets CLOSEFILE', async () => {
+    const fs = new ServerVirtualFileSystem();
+
+    // First run writes but never closes the file — closeAll() should flush it at end-of-run.
+    const write = [
+      'OPENFILE "kept.txt" FOR WRITE',
+      'WRITEFILE "kept.txt", "kept"',
+    ].join('\n') + '\n';
+    await runCode(write, [], fs);
+
+    // A later run on the same filesystem can read what was written.
+    const read = [
+      'OPENFILE "kept.txt" FOR READ',
+      'READFILE "kept.txt", line',
+      'OUTPUT line',
+    ].join('\n') + '\n';
+    const { outputs } = await runCode(read, [], fs);
+    expect(outputs).toEqual(['kept']);
   });
 });
 

--- a/app/src/interpreter/core/filesystem.ts
+++ b/app/src/interpreter/core/filesystem.ts
@@ -1,4 +1,5 @@
 import { RuntimeError } from './types';
+import { FILE_PREFIX, FILES_CHANGED_EVENT } from '../../utils/constants';
 
 type FileMode = 'READ' | 'WRITE' | 'APPEND' | 'RANDOM';
 
@@ -10,7 +11,6 @@ interface OpenFile {
   records: Map<number, string> | null;
 }
 
-const STORAGE_PREFIX = 'pseudocode_file_';
 const RANDOM_FILE_MARKER = '__pseudoRandomFile';
 
 function parseRandomFile(content: string): Map<number, string> | null {
@@ -33,6 +33,10 @@ function stringifyRandomFile(records: Map<number, string>): string {
 
 export class VirtualFileSystem {
   private openFiles = new Map<string, OpenFile>();
+  /** Writable files touched since the last flush — coalesced into one storage write per frame. */
+  private dirty = new Set<string>();
+  /** Pending requestAnimationFrame handle for the batched flush, or null when none is scheduled. */
+  private flushHandle: number | null = null;
 
   openFile(filename: string, mode: FileMode): void {
     if (this.openFiles.has(filename)) {
@@ -40,7 +44,7 @@ export class VirtualFileSystem {
     }
 
     if (mode === 'RANDOM') {
-      const content = localStorage.getItem(STORAGE_PREFIX + filename);
+      const content = localStorage.getItem(FILE_PREFIX + filename);
       let records = new Map<number, string>();
       if (content !== null && content !== '') {
         const parsed = parseRandomFile(content);
@@ -54,7 +58,7 @@ export class VirtualFileSystem {
     }
 
     if (mode === 'READ') {
-      const content = localStorage.getItem(STORAGE_PREFIX + filename);
+      const content = localStorage.getItem(FILE_PREFIX + filename);
       if (content === null) {
         throw new RuntimeError(`File '${filename}' does not exist`);
       }
@@ -67,7 +71,7 @@ export class VirtualFileSystem {
       this.openFiles.set(filename, { mode, lines: [], pointer: 0, records: null });
     } else {
       // APPEND
-      const content = localStorage.getItem(STORAGE_PREFIX + filename) ?? '';
+      const content = localStorage.getItem(FILE_PREFIX + filename) ?? '';
       const lines = content === '' ? [] : content.split('\n');
       this.openFiles.set(filename, { mode, lines, pointer: lines.length, records: null });
     }
@@ -96,6 +100,8 @@ export class VirtualFileSystem {
       throw new RuntimeError(`File '${filename}' is not open for writing`);
     }
     file.lines.push(data);
+    // Persist eagerly so an open Files panel updates live — coalesced to one write per frame.
+    this.scheduleFlush(filename);
   }
 
   closeFile(filename: string): void {
@@ -103,12 +109,11 @@ export class VirtualFileSystem {
     if (!file) {
       throw new RuntimeError(`File '${filename}' is not open`);
     }
-    if (file.mode === 'WRITE' || file.mode === 'APPEND') {
-      localStorage.setItem(STORAGE_PREFIX + filename, file.lines.join('\n'));
-    } else if (file.mode === 'RANDOM') {
-      localStorage.setItem(STORAGE_PREFIX + filename, stringifyRandomFile(file.records!));
-    }
+    // Flush synchronously on an explicit close so storage errors (e.g. quota) surface to the student.
+    this.persist(filename, file);
+    this.dirty.delete(filename);
     this.openFiles.delete(filename);
+    this.emitChange([filename]);
   }
 
   eof(filename: string): boolean {
@@ -153,9 +158,89 @@ export class VirtualFileSystem {
   putRecord(filename: string, data: string): void {
     const file = this.randomFile(filename, 'PUTRECORD');
     file.records!.set(file.pointer, data);
+    this.scheduleFlush(filename);
+  }
+
+  /**
+   * Flush every still-open writable file to storage and drop all handles. This is the
+   * durability backstop the interpreter calls when a run ends — it guarantees data
+   * survives even when the student forgot CLOSEFILE, and forces out the final rAF frame
+   * that may still be pending. It runs inside the interpreter's `finally`, so it must
+   * never throw (a throw here would mask the program's real error).
+   */
+  closeAll(): void {
+    if (this.flushHandle !== null) {
+      cancelAnimationFrame(this.flushHandle);
+      this.flushHandle = null;
+    }
+    const changed: string[] = [];
+    for (const [name, file] of this.openFiles) {
+      try {
+        this.persist(name, file);
+        changed.push(name);
+      } catch {
+        // storage full / unavailable — swallow so we don't hide the program's outcome
+      }
+    }
+    this.openFiles.clear();
+    this.dirty.clear();
+    if (changed.length) this.emitChange(changed);
   }
 
   reset(): void {
+    if (this.flushHandle !== null) {
+      cancelAnimationFrame(this.flushHandle);
+      this.flushHandle = null;
+    }
     this.openFiles.clear();
+    this.dirty.clear();
+  }
+
+  // ─── persistence helpers ────────────────────────────────────────
+
+  /** Write one open file's current buffer to localStorage. READ files are never persisted. */
+  private persist(filename: string, file: OpenFile): void {
+    if (file.mode === 'WRITE' || file.mode === 'APPEND') {
+      localStorage.setItem(FILE_PREFIX + filename, file.lines.join('\n'));
+    } else if (file.mode === 'RANDOM') {
+      localStorage.setItem(FILE_PREFIX + filename, stringifyRandomFile(file.records!));
+    }
+  }
+
+  /** Mark a file dirty and coalesce a storage flush into the next animation frame. */
+  private scheduleFlush(filename: string): void {
+    this.dirty.add(filename);
+    if (typeof requestAnimationFrame === 'undefined') {
+      // No rAF (SSR / non-browser) — persist immediately.
+      this.flushDirty();
+      return;
+    }
+    if (this.flushHandle === null) {
+      this.flushHandle = requestAnimationFrame(() => this.flushDirty());
+    }
+  }
+
+  /** Persist every dirty file in one batch, then notify listeners (live Files panel). */
+  private flushDirty(): void {
+    this.flushHandle = null;
+    const changed: string[] = [];
+    for (const name of this.dirty) {
+      const file = this.openFiles.get(name);
+      if (!file) continue; // closed before the frame fired — already persisted
+      try {
+        this.persist(name, file);
+        changed.push(name);
+      } catch {
+        // storage full / unavailable — drop this frame's write silently
+      }
+    }
+    this.dirty.clear();
+    if (changed.length) this.emitChange(changed);
+  }
+
+  /** Tell any open Files panel which files just changed on disk. */
+  private emitChange(files: string[]): void {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new CustomEvent(FILES_CHANGED_EVENT, { detail: { files } }));
   }
 }

--- a/app/src/interpreter/core/interpreter.ts
+++ b/app/src/interpreter/core/interpreter.ts
@@ -294,6 +294,11 @@ export class Interpreter {
       } else {
         throw e;
       }
+    } finally {
+      // Durability backstop: flush any file the student left open (forgot CLOSEFILE) and
+      // force out the final pending flush frame. Runs on every exit — success, abort,
+      // RETURN-at-top-level and runtime error alike. closeAll() never throws.
+      this.fileSystem.closeAll();
     }
   }
 

--- a/app/src/interpreter/core/serverFilesystem.ts
+++ b/app/src/interpreter/core/serverFilesystem.ts
@@ -148,6 +148,24 @@ export class ServerVirtualFileSystem {
     this.store.set(filename, content);
   }
 
+  /**
+   * Flush every still-open writable file to the backing store and drop all handles.
+   * Mirrors {@link VirtualFileSystem.closeAll}: the interpreter calls this when a run
+   * ends so data survives even when the student forgot CLOSEFILE. Writes stay buffered
+   * (no per-line persistence) since there is no live viewer to feed server-side. Never
+   * throws — it runs in the interpreter's `finally`.
+   */
+  closeAll(): void {
+    for (const [name, file] of this.openFiles) {
+      if (file.mode === 'WRITE' || file.mode === 'APPEND') {
+        this.store.set(name, file.lines.join('\n'));
+      } else if (file.mode === 'RANDOM') {
+        this.store.set(name, stringifyRandomFile(file.records!));
+      }
+    }
+    this.openFiles.clear();
+  }
+
   reset(): void {
     this.openFiles.clear();
     this.store.clear();

--- a/app/src/utils/constants.ts
+++ b/app/src/utils/constants.ts
@@ -25,6 +25,13 @@ export const SPLIT_COMPILER_COLLAPSED_KEY = 'pseudocode-split-compiler-collapsed
 /** Window CustomEvent name that opens the global "Report a bug" modal */
 export const OPEN_BUG_REPORT_EVENT = 'pseudocode:open-bug-report';
 
+/**
+ * Window CustomEvent fired when the interpreter persists file(s) to localStorage
+ * (on WRITEFILE/PUTRECORD flush, CLOSEFILE, or end-of-run). `detail.files` lists
+ * the changed file names so an open Files panel can refresh live.
+ */
+export const FILES_CHANGED_EVENT = 'pseudocode:files-changed';
+
 /** Session-only snapshot of the main compiler's latest terminal output. */
 export const BUG_REPORT_OUTPUT_KEY = 'pseudocode_bug_report_output';
 


### PR DESCRIPTION
## What & why

`WRITEFILE`/`PUTRECORD` previously buffered in memory and only persisted to storage on `CLOSEFILE`. A program that forgot `CLOSEFILE` silently lost its output (the original bug report), and nothing showed in the Files panel until a run finished.

This makes file writes **persist eagerly** and adds a **guaranteed flush at end-of-run**, plus a **live-updating Files panel**.

## Changes

- **`core/filesystem.ts`** — eager write-through, coalesced into one `localStorage.setItem` per animation frame (mirrors the interpreter's existing `onOutput` rAF batching, so a 10k-line write loop doesn't do 10k storage writes / go O(n²)). Each flush fires a `FILES_CHANGED_EVENT`. Deduped the storage prefix onto `FILE_PREFIX`.
- **`core/interpreter.ts`** — `execute()` calls `fileSystem.closeAll()` in a `finally`: a durability backstop that flushes anything left open and forces out the final pending frame on **every** exit (success, abort, runtime error, top-level `RETURN`). `closeAll()` never throws, so it can't mask a program's real error.
- **`core/serverFilesystem.ts`** — adds `closeAll()` only; stays buffered (no live viewer server-side, and per-line write-through would be O(n²)).
- **`utils/constants.ts`** — new `FILES_CHANGED_EVENT`.
- **`components/compiler/fileViewer.tsx`** — subscribes to `FILES_CHANGED_EVENT` and refreshes the list + the open file's contents live (open the Files panel mid-run and watch a file fill in).

## Deliberate behavior changes

- Forgetting `CLOSEFILE` now still saves the file (the fix).
- Aborting / erroring mid-program now persists partial writes (was: nothing).
- `OPENFILE ... FOR WRITE` then an error/abort *before* any `WRITEFILE` now truncates the file to empty, matching C `fopen "w"` (was: old content preserved).

## Grading impact

None. `autograder.ts` compares terminal output only and never reads back files from the VFS.

## Testing

- `tsc --noEmit` clean
- ESLint: 0 errors (only pre-existing warnings, none in touched files)
- **213/213** vitest tests pass, including a new test asserting a forgotten `CLOSEFILE` still persists across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)